### PR TITLE
Added `pr-patch-coverage` cmd to create PR patch coverage

### DIFF
--- a/cmd/pr-patch-coverage.go
+++ b/cmd/pr-patch-coverage.go
@@ -8,6 +8,7 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/codeclimate/test-reporter/env"
 	"github.com/codeclimate/test-reporter/formatters"
 	"github.com/pkg/errors"
@@ -57,7 +58,7 @@ func getDiffLineMapping(fromString string) (diffLineMapping, error) {
 	if len(matches) >= 4 {
 		// Get names of the capturing groups
 		names := lineNumberRegex.SubexpNames()
-		println(fmt.Sprintf("Matches: %v, Names: %v", matches, names))
+		logrus.Debugf("Matches: %v, Names: %v", matches, names)
 		// Create a map of group names to their values
 		result := make(map[string]int)
 		for i, name := range names {
@@ -74,8 +75,8 @@ func getDiffLineMapping(fromString string) (diffLineMapping, error) {
 			}
 		}
 
-		println(fmt.Sprintf("Line before: %d, Count before: %d, Line after: %d, Count after: %d",
-			result["lineBefore"], result["countBefore"], result["lineAfter"], result["countAfter"]))
+		logrus.Debugf("Line before: %d, Count before: %d, Line after: %d, Count after: %d",
+			result["lineBefore"], result["countBefore"], result["lineAfter"], result["countAfter"])
 
 		var deletedStart int
 		if result["countBefore"] == 0 {
@@ -262,14 +263,14 @@ func (p PrPatchGenerator) generatePatchReport(fromReport formatters.Report) (for
 			Coverage: make([]formatters.NullInt, len(fileContentLines)),
 		}
 
-		println(prFileDiff.String())
+		logrus.Debug(prFileDiff.String())
 
 		// Setting
 		success := true
 		for i := range fileContentLines {
 			lineNo := i + 1
 			if prFileDiff.withinAddedPatch(lineNo) {
-				fmt.Printf("[Patch check] fileName: %s, lineNo: %d\n", fileName, lineNo)
+				logrus.Debugf("[Patch check] fileName: %s, lineNo: %d\n", fileName, lineNo)
 				afterLineNo, err := prFileDiffLastMerge.getAddedLineFor(lineNo)
 				if err != nil {
 					success = false
@@ -294,9 +295,9 @@ var prPatchOptions = PrPatchGenerator{}
 
 func getFileMappingFromDiff() error {
 	for _, file := range prPatchOptions.prFiles {
-		println("File: " + file)
+		logrus.Debug("File: " + file)
 		// Generating file diff between the mergeBaseCommit and headTipCommit
-		println("diff between the mergeBaseCommit and headTipCommit :-")
+		logrus.Debug("diff between the mergeBaseCommit and headTipCommit :-")
 		diff, err := loadFromGit("diff", "-U0", prPatchOptions.mergeBaseCommit, prPatchOptions.headTipCommit, "--", file)
 		if err != nil {
 			return err
@@ -309,7 +310,7 @@ func getFileMappingFromDiff() error {
 		}
 
 		// Generating file diff between the headTipCommit and lastMergeCommit
-		println("diff between the headTipCommit and lastMergeCommit :-")
+		logrus.Debug("diff between the headTipCommit and lastMergeCommit :-")
 		diff, err = loadFromGit("diff", "-U0", prPatchOptions.headTipCommit, prPatchOptions.lastMergeCommit, "--", file)
 		if err != nil {
 			return err
@@ -362,7 +363,7 @@ func updatePrPatchOptions() error {
 		return err
 	}
 	prPatchOptions.prFiles = strings.Split(files, "\n")
-	println(prPatchOptions.String())
+	logrus.Debug(prPatchOptions.String())
 
 	if err := getFileMappingFromDiff(); err != nil {
 		return err

--- a/cmd/pr-patch-coverage.go
+++ b/cmd/pr-patch-coverage.go
@@ -1,0 +1,117 @@
+package cmd
+
+import (
+	"os"
+	"os/exec"
+	"strings"
+
+	"github.com/codeclimate/test-reporter/env"
+	"github.com/pkg/errors"
+	"github.com/spf13/cobra"
+)
+
+type PrPatchGenerator struct {
+	baseBranch      string
+	headBranch      string
+	headTipCommit   string
+	lastMergeCommit string
+	mergeBaseCommit string
+	prFiles         []string
+}
+
+func (p PrPatchGenerator) String() string {
+	out := &strings.Builder{}
+	out.WriteString("base-branch: ")
+	out.WriteString(p.baseBranch)
+	out.WriteString("\n")
+	out.WriteString("head-branch: ")
+	out.WriteString(p.headBranch)
+	out.WriteString("\n")
+	out.WriteString("head-tip-commit: ")
+	out.WriteString(p.headTipCommit)
+	out.WriteString("\n")
+	out.WriteString("last-merge-commit: ")
+	out.WriteString(p.lastMergeCommit)
+	out.WriteString("\n")
+	out.WriteString("merge-base-commit: ")
+	out.WriteString(p.mergeBaseCommit)
+	out.WriteString("\n")
+	out.WriteString("pr-files: ")
+	out.WriteString(strings.Join(p.prFiles, ", "))
+	return out.String()
+}
+
+var prPatchOptions = PrPatchGenerator{}
+
+func updatePrPatchOptions(args []string) error {
+	if prPatchOptions.baseBranch == "" {
+		return errors.New("base-branch is required")
+	}
+	if prPatchOptions.headBranch == "" {
+		e, err := env.New()
+		if err != nil {
+			return err
+		}
+		prPatchOptions.headBranch = e.Git.Branch
+	}
+	if prPatchOptions.headTipCommit == "" {
+		commit, err := loadFromGit("rev-parse", "origin/"+prPatchOptions.headBranch)
+		if err != nil {
+			return err
+		}
+		prPatchOptions.headTipCommit = commit
+	}
+	if prPatchOptions.lastMergeCommit == "" {
+		commit, err := loadFromGit("rev-parse", prPatchOptions.headBranch)
+		if err != nil {
+			return err
+		}
+		prPatchOptions.lastMergeCommit = commit
+	}
+	// Get the merge base commit
+	commit, err := loadFromGit("merge-base", prPatchOptions.baseBranch, prPatchOptions.headTipCommit)
+	if err != nil {
+		return err
+	}
+	prPatchOptions.mergeBaseCommit = commit
+
+	// Get the list of files changed in the PR
+	files, err := loadFromGit("diff", "--name-only", prPatchOptions.mergeBaseCommit, prPatchOptions.headTipCommit)
+	if err != nil {
+		return err
+	}
+	prPatchOptions.prFiles = strings.Split(files, "\n")
+
+	return nil
+}
+
+var prPatchCoverageCmd = &cobra.Command{
+	Use:   "pr-patch-coverage",
+	Short: "Generates patch coverage for PR. Needs to be run after format-coverage",
+	RunE: func(cmd *cobra.Command, args []string) error {
+		if err := updatePrPatchOptions(args); err != nil {
+			return err
+		}
+		println(prPatchOptions.String())
+		return nil
+	},
+}
+
+func loadFromGit(gitArgs ...string) (string, error) {
+	cmd := exec.Command("git", gitArgs...)
+	cmd.Stderr = os.Stderr
+	out, err := cmd.Output()
+	if err != nil {
+		return "", errors.WithStack(err)
+	}
+
+	return strings.TrimSpace(string(out)), nil
+}
+
+func init() {
+	prPatchCoverageCmd.Flags().StringVar(&prPatchOptions.baseBranch, "base-branch", "", "the base branch of the PR")
+	prPatchCoverageCmd.Flags().StringVar(&prPatchOptions.headBranch, "head-branch", "", "the head branch of the PR")
+	prPatchCoverageCmd.Flags().StringVar(&prPatchOptions.headTipCommit, "head-tip-commit", "", "commit on tip of PR head branch")
+	prPatchCoverageCmd.Flags().StringVar(&prPatchOptions.lastMergeCommit, "last-merge-commit", "", "last merge commit on the head branch")
+	RootCmd.AddCommand(prPatchCoverageCmd)
+}

--- a/cmd/pr-patch-coverage.go
+++ b/cmd/pr-patch-coverage.go
@@ -14,7 +14,7 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const defaultPrPatchCoveragePath = "coverage/patch_coverage.json"
+const defaultPrPatchCoveragePath = "coverage/artifact-pr-patch-coverage-results.json"
 
 type diffLineMapping struct {
 	deletedStart int

--- a/cmd/pr-patch-coverage.go
+++ b/cmd/pr-patch-coverage.go
@@ -1,8 +1,10 @@
 package cmd
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
+	"regexp"
 	"strings"
 
 	"github.com/codeclimate/test-reporter/env"
@@ -85,6 +87,49 @@ func updatePrPatchOptions(args []string) error {
 	return nil
 }
 
+func getFileMappingFromDiff() error {
+	headBranchOrigin := "origin/" + prPatchOptions.headBranch
+	lineNumberRegex := regexp.MustCompile(`@@ -(?P<lineBefore>\d+),?(?P<countBefore>\d+)? \+(?P<lineAfter>\d+),?(?P<countAfter>\d+)? @@`)
+
+	for _, file := range prPatchOptions.prFiles {
+		diff, err := loadFromGit("diff", "-U0", headBranchOrigin, "HEAD", "--", file)
+		if err != nil {
+			return err
+		}
+
+		println("File: " + file)
+		for _, line := range strings.Split(diff, "\n") {
+			if strings.Contains(line, "@@") {
+				matches := lineNumberRegex.FindStringSubmatch(line)
+				if len(matches) >= 4 {
+					// Get names of the capturing groups
+					names := lineNumberRegex.SubexpNames()
+					println(fmt.Sprintf("Matches: %v, Names: %v", matches, names))
+					// Create a map of group names to their values
+					result := make(map[string]int)
+					for i, name := range names {
+						// names[i] is always an empty string from SubexpNames
+						if i != 0 && name != "" && i < len(matches) {
+							// Convert string to integer, default to 1 if empty
+							val := matches[i]
+							if val == "" {
+								val = "1"
+							}
+							num := 0
+							fmt.Sscanf(val, "%d", &num)
+							result[name] = num
+						}
+					}
+
+					println(fmt.Sprintf("Line before: %d, Count before: %d, Line after: %d, Count after: %d",
+						result["lineBefore"], result["countBefore"], result["lineAfter"], result["countAfter"]))
+				}
+			}
+		}
+	}
+	return nil
+}
+
 var prPatchCoverageCmd = &cobra.Command{
 	Use:   "pr-patch-coverage",
 	Short: "Generates patch coverage for PR. Needs to be run after format-coverage",
@@ -93,6 +138,11 @@ var prPatchCoverageCmd = &cobra.Command{
 			return err
 		}
 		println(prPatchOptions.String())
+
+		if err := getFileMappingFromDiff(); err != nil {
+			return err
+		}
+
 		return nil
 	},
 }

--- a/cmd/pr-patch-coverage.go
+++ b/cmd/pr-patch-coverage.go
@@ -220,7 +220,7 @@ func (p PrPatchGenerator) generatePatchReport(fromReport formatters.Report) (for
 	patchReport := formatters.Report{
 		SourceFiles: formatters.SourceFiles{},
 	}
-	ignoredLine := formatters.NullInt{-1, false}
+	ignoredLine := formatters.NullInt{Int: -1, Valid: false}
 
 	// Iterate over the source files in the report
 	for _, sourceFile := range fromReport.SourceFiles {
@@ -266,7 +266,7 @@ func (p PrPatchGenerator) generatePatchReport(fromReport formatters.Report) (for
 
 		// Setting
 		success := true
-		for i, _ := range fileContentLines {
+		for i := range fileContentLines {
 			lineNo := i + 1
 			if prFileDiff.withinAddedPatch(lineNo) {
 				fmt.Printf("[Patch check] fileName: %s, lineNo: %d\n", fileName, lineNo)


### PR DESCRIPTION
# Description
Added `pr-patch-coverage` cmd to convert the output coverage which only includes Pull Request diff coverage.

### Usage
```bash
test-reporter pr-patch-coverage --base-branch master coverage/artifact-coverage-results.json
```

### Help options
```
$ test-reporter pr-patch-coverage --help
Generates patch coverage for PR. Needs to be run after format-coverage

Usage:
  cc-test-reporter pr-patch-coverage [flags]

Flags:
      --base-branch string         the base branch of the PR
      --head-branch string         the head branch of the PR
      --head-tip-commit string     commit on tip of PR head branch
      --last-merge-commit string   last merge commit on the head branch
      --output string              output path (default "coverage/artifact-pr-patch-coverage-results.json")

Global Flags:
  -d, --debug   run in debug mode
```